### PR TITLE
GUACAMOLE-436: Update website to reflect git repository and dist area rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Testing changes locally
 To test your changes to the website, you can either invoke `./build.sh` to build a static copy of the site to the `content/` subdirectory, or invoke `./build.sh PORT` (where `PORT` a TCP port number) to both build the static copy of the site *and* run Ruby's web server to serve `content/` locally at the given port:
 
     $ ./build.sh 8080
-    Configuration file: /home/mjumper/apache-guacamole/incubator-guacamole-website/_config.yml
-                Source: /home/mjumper/apache-guacamole/incubator-guacamole-website
-           Destination: /home/mjumper/apache-guacamole/incubator-guacamole-website/_site
+    Configuration file: /home/mjumper/apache-guacamole/guacamole-website/_config.yml
+                Source: /home/mjumper/apache-guacamole/guacamole-website
+           Destination: /home/mjumper/apache-guacamole/guacamole-website/_site
      Incremental build: disabled. Enable with --incremental
           Generating...
                         done in 0.563 seconds.
@@ -109,9 +109,9 @@ The `build.sh` script can take care of all this for you when invoked as
 `./build.sh stage`:
 
     $ ./build.sh stage
-    Configuration file: /home/mjumper/apache-guacamole/incubator-guacamole-website/_config.yml
-                Source: /home/mjumper/apache-guacamole/incubator-guacamole-website
-           Destination: /home/mjumper/apache-guacamole/incubator-guacamole-website/_site
+    Configuration file: /home/mjumper/apache-guacamole/guacamole-website/_config.yml
+                Source: /home/mjumper/apache-guacamole/guacamole-website
+           Destination: /home/mjumper/apache-guacamole/guacamole-website/_site
      Incremental build: disabled. Enable with --incremental
           Generating...
                         done in 0.568 seconds.

--- a/_links/community/github.md
+++ b/_links/community/github.md
@@ -1,5 +1,5 @@
 ---
 menu-title:  GitHub
 menu-weight: 1
-location:    https://github.com/search?utf8=%E2%9C%93&q=repo%3Aapache%2Fincubator-guacamole-server+repo%3Aapache%2Fincubator-guacamole-client+repo%3Aapache%2Fincubator-guacamole-website&type=Repositories&ref=searchresults
+location:    https://github.com/search?utf8=%E2%9C%93&q=repo%3Aapache%2Fguacamole-server+repo%3Aapache%2Fguacamole-client+repo%3Aapache%2Fguacamole-website&type=Repositories&ref=searchresults
 ---

--- a/_releases/0.9.12-incubating.md
+++ b/_releases/0.9.12-incubating.md
@@ -8,8 +8,8 @@ summary: >
     improvements, and fixes for printing, file transfer, and terminal
     emulation.
 
-artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://www.apache.org/dist/"
+artifact-root: "http://archive.apache.org/dist/"
+checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.12-incubating/"
 
 source-dist:

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -9,7 +9,7 @@ summary: >
 
 artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
 checksum-root: "https://www.apache.org/dist/"
-download-path: "incubator/guacamole/0.9.13-incubating/"
+download-path: "guacamole/0.9.13-incubating/"
 
 source-dist:
     - "source/guacamole-client-0.9.13-incubating.tar.gz"

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -89,7 +89,7 @@ backward or forward within that stream.
 
 This missing API-level functionality is now provided through the new
 [`Guacamole.StaticHTTPTunnel`](/doc/0.9.13-incubating/guacamole-common-js/Guacamole.StaticHTTPTunnel.html) and [`Guacamole.SessionRecording`](/doc/0.9.13-incubating/guacamole-common-js/Guacamole.SessionRecording.html) objects respectively,
-and an example demonstrating this use, [guacamole-playback-example](https://github.com/apache/incubator-guacamole-client/tree/de12b683d746129ddc8b34425ed6e40b618c91d6/doc/guacamole-playback-example), is provided within the guacamole-client source.
+and an example demonstrating this use, [guacamole-playback-example](https://github.com/apache/guacamole-client/tree/de12b683d746129ddc8b34425ed6e40b618c91d6/doc/guacamole-playback-example), is provided within the guacamole-client source.
 
  * [GUACAMOLE-250](https://issues.apache.org/jira/browse/GUACAMOLE-250) - Implement support for in-browser playback of screen recordings
 

--- a/open-source.md
+++ b/open-source.md
@@ -92,7 +92,7 @@ a committer not otherwise directly involved in those changes.
 
 * [Committers' FAQ](http://www.apache.org/dev/committers.html)
 * [Guide for new committers](http://www.apache.org/dev/new-committers-guide.html)
-* [Maintaining the website](https://github.com/apache/incubator-guacamole-website/blob/master/README.md)
+* [Maintaining the website](https://github.com/apache/guacamole-website/blob/master/README.md)
 * [Managing pull requests](/pull-requests/)
 * [Style guidelines](/guac-style/)
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -22,12 +22,12 @@ You will need three remotes for each Apache Guacamole git repository:
 
 For the sake of simplicity, these will be referred to here as `upstream`,
 `mirror`, and `origin`, respectively. For example, the recommended
-configuration for `incubator-guacamole-server` would be:
+configuration for `guacamole-server` would be:
 
     $ git remote -v
-    mirror git@github.com:apache/incubator-guacamole-server.git
-    origin git@github.com:mike-jumper/incubator-guacamole-server.git
-    upstream https://git-wip-us.apache.org/repos/asf/incubator-guacamole-server.git
+    mirror git@github.com:apache/guacamole-server.git
+    origin git@github.com:mike-jumper/guacamole-server.git
+    upstream https://git-wip-us.apache.org/repos/asf/guacamole-server.git
     $
 
 After reviewing and approving code submitted via a pull request, you will need

--- a/release-procedure-part1.md
+++ b/release-procedure-part1.md
@@ -42,12 +42,12 @@ Create a new `staging/[VERSION]` branch for each of the following repositories,
 where `[VERSION]` is the version of the upcoming release, such as
 "0.9.11":
 
- * [`incubator-guacamole-client`](https://github.com/apache/incubator-guacamole-client)
- * [`incubator-guacamole-server`](https://github.com/apache/incubator-guacamole-server)
- * [`incubator-guacamole-manual`](https://github.com/apache/incubator-guacamole-manual)
+ * [`guacamole-client`](https://github.com/apache/guacamole-client)
+ * [`guacamole-server`](https://github.com/apache/guacamole-server)
+ * [`guacamole-manual`](https://github.com/apache/guacamole-manual)
 
 Note that *the
-[`incubator-guacamole-website`](https://github.com/apache/incubator-guacamole-website)
+[`guacamole-website`](https://github.com/apache/guacamole-website)
 repository does not get a release branch*. The website points to release
 artifacts, etc. but is not itself part of the release.
 
@@ -76,9 +76,9 @@ dependencies being modified, and thus bumped as well. For example:
    all extensions will need to be modified to specify the correct version
    number in their `guac-manifest.json`.
 
-### Bumping the version of `incubator-guacamole-server`
+### Bumping the version of `guacamole-server`
 
-The main locations which need modification within `incubator-guacamole-server`
+The main locations which need modification within `guacamole-server`
 are:
 
  * `configure.ac`
@@ -88,11 +88,11 @@ are:
  * `bin/guacctl`
  * The manpages for `guacd`, `guacenc`, and `guacd.conf`.
 
-Example: [the pull request for bumping `incubator-guacamole-server` to 0.9.11-incubating](https://github.com/apache/incubator-guacamole-server/pull/34)
+Example: [the pull request for bumping `guacamole-server` to 0.9.11-incubating](https://github.com/apache/guacamole-server/pull/34)
 
-### Bumping the version of `incubator-guacamole-client`
+### Bumping the version of `guacamole-client`
 
-The main locations which need modification within `incubator-guacamole-client`
+The main locations which need modification within `guacamole-client`
 are:
 
  * The `pom.xml` of any modified project, as well as any project which depends
@@ -102,11 +102,11 @@ are:
  * The `Guacamole.API_VERSION` value declared within `Version.js` (if
    `guacamole-common-js` has been modified).
 
-Example: [the pull request for bumping `incubator-guacamole-client` to 0.9.11-incubating](https://github.com/apache/incubator-guacamole-client/pull/103)
+Example: [the pull request for bumping `guacamole-client` to 0.9.11-incubating](https://github.com/apache/guacamole-client/pull/103)
 
-### Updating `incubator-guacamole-manual` accordingly
+### Updating `guacamole-manual` accordingly
 
-The manual (`incubator-guacamole-manual`) will also need to be updated to point
+The manual (`guacamole-manual`) will also need to be updated to point
 to the latest versions of everything. In most cases, this involves simply
 replacing the old version number with the new version number wherever it
 occurs, but the process needs to be selective if not all components have been
@@ -116,5 +116,5 @@ modified. In particular, watch out for:
  * The need to update the webapp, authentication, and protocol plugin
    tutorials.
 
-Example: [the pull request for bumping `incubator-guacamole-manual` to 0.9.11-incubating](https://github.com/apache/incubator-guacamole-manual/pull/23)
+Example: [the pull request for bumping `guacamole-manual` to 0.9.11-incubating](https://github.com/apache/guacamole-manual/pull/23)
 

--- a/release-procedure-part2.md
+++ b/release-procedure-part2.md
@@ -22,11 +22,11 @@ candidate:
 
 Each repository relevant to the release must be tagged. At this point, this
 will be every repository that has a release branch. This *never* includes
-`incubator-guacamole-website`, which is not part of the release.
+`guacamole-website`, which is not part of the release.
 
 Example: [the
 "0.9.10-incubating-RC3" tag on
-incubator-guacamole-server](https://git1-us-west.apache.org/repos/asf?p=incubator-guacamole-server.git;a=tag;h=6c2bc47a93899cf00a869e7a2a5416fd5b081ed3)
+guacamole-server](https://git1-us-west.apache.org/repos/asf?p=guacamole-server.git;a=tag;h=6c2bc47a93899cf00a869e7a2a5416fd5b081ed3)
 
 
 Sign and upload release artifacts {#upload-rc}
@@ -54,14 +54,14 @@ There are currently two source artifacts:
  * `guacamole-server-[VERSION].tar.gz`
 
 `guacamole-client-[VERSION].tar.gz` is created automatically when
-`incubator-guacamole-client` is built with `mvn clean install`.
+`guacamole-client` is built with `mvn clean install`.
 `guacamole-server-[VERSION].tar.gz` can be built manually by running `make
-dist` within `incubator-guacamole-server`. The `Makefile`, etc. will need to
+dist` within `guacamole-server`. The `Makefile`, etc. will need to
 have been generated first by running `autoreconf -fi` followed by
 `./configure`.
 
-`incubator-guacamole-server` does not provide any convenience binaries, but
-`incubator-guacamole-client` does:
+`guacamole-server` does not provide any convenience binaries, but
+`guacamole-client` does:
 
  * `guacamole-[VERSION].war`
  * `guacamole-auth-duo-[VERSION].tar.gz`
@@ -70,7 +70,7 @@ have been generated first by running `autoreconf -fi` followed by
  * `guacamole-auth-ldap-[VERSION].tar.gz`
  * `guacamole-auth-noauth-[VERSION].tar.gz`
 
-Each of the above can be found within the `incubator-guacamole-client` source
+Each of the above can be found within the `guacamole-client` source
 tree once it has been built with `mvn clean install`.
 
 Producing the required MD5 and SHA256 checksums for a given artifact is very
@@ -88,7 +88,7 @@ Example: [the SVN commit uploading RC1 of 0.9.10-incubating (r17053)](https://di
 
 ### Maven artifacts {#staging-maven}
 
-The following Maven subprojects of `incubator-guacamole-client` must be
+The following Maven subprojects of `guacamole-client` must be
 uploaded to Apache's Nexus:
 
  * `guacamole-common` (`.jar`, source, and javadoc)
@@ -169,7 +169,7 @@ When building the Docker images, keep in mind:
    the Docker image must be built with that tag.
 
 For example, to build the `guacamole/guacamole` Docker image for the current
-release candidate, from within the top-level `incubator-guacamole-client`
+release candidate, from within the top-level `guacamole-client`
 directory:
 
     $ git clean -xfd .
@@ -183,9 +183,9 @@ Upload documentation and release notes {#upload-docs}
 The draft release notes and updated documentation both need to be uploaded to
 the website prior to [calling the PMC vote](#pmc-vote). These changes should
 be handled like any other website changes - via pull requests against the
-`incubator-guacamole-website` repository. **DO NOT UPDATE THE TOP-LEVEL
+`guacamole-website` repository. **DO NOT UPDATE THE TOP-LEVEL
 DOCUMENTATION SYMBOLIC LINKS!** The top-level symbolic links in the `doc/`
-directory of `incubator-guacamole-website` point to the documentation for the
+directory of `guacamole-website` point to the documentation for the
 latest release, and are thus only updated once the release is complete.
 
 Take a look at past release notes to get an idea for the expected format. There
@@ -204,8 +204,8 @@ of auto-generated HTML otherwise.
 Examples:
 
  * [The draft
-release notes for 0.9.10-incubating-RC3](https://github.com/apache/incubator-guacamole-website/blob/67adf0802701d696f9dc1a90229da694f4cebbaa/_releases/0.9.10-incubating.md)
- * [The updated documentation for 0.9.10-incubating](https://github.com/apache/incubator-guacamole-website/tree/master/doc/0.9.10-incubating)
+release notes for 0.9.10-incubating-RC3](https://github.com/apache/guacamole-website/blob/67adf0802701d696f9dc1a90229da694f4cebbaa/_releases/0.9.10-incubating.md)
+ * [The updated documentation for 0.9.10-incubating](https://github.com/apache/guacamole-website/tree/master/doc/0.9.10-incubating)
 
 Create the PMC `[VOTE]` thread {#ppmc-vote}
 -------------------------------------------
@@ -226,9 +226,9 @@ http://guacamole.apache.org/releases/[VERSION]/
 
 The git tag for all relevant repositories is "[VERSION]-RC[N]":
 
-https://github.com/apache/incubator-guacamole-client/tree/[VERSION]-RC[N]
-https://github.com/apache/incubator-guacamole-server/tree/[VERSION]-RC[N]
-https://github.com/apache/incubator-guacamole-manual/tree/[VERSION]-RC[N]
+https://github.com/apache/guacamole-client/tree/[VERSION]-RC[N]
+https://github.com/apache/guacamole-server/tree/[VERSION]-RC[N]
+https://github.com/apache/guacamole-manual/tree/[VERSION]-RC[N]
 
 Build instructions are included in the manual, which is part of the updated
 documentation referenced above. For convenience:

--- a/release-procedure-part3.md
+++ b/release-procedure-part3.md
@@ -37,10 +37,10 @@ format `[VERSION]`, where `[VERSION]` is the version of the release:
 Just as with release candidates, each repository relevant to the release must
 be tagged. This will be every repository that had a release branch (the release
 branch having been [deleted earlier](#delete-branch)) and *never* includes
-`incubator-guacamole-website`, which is not part of the release.
+`guacamole-website`, which is not part of the release.
 
 Example: [the "0.9.10-incubating" tag on
-incubator-guacamole-server](https://git1-us-west.apache.org/repos/asf?p=incubator-guacamole-server.git;a=tag;h=0875ca8f4e86b942b466cfebf84cc33c47095130)
+guacamole-server](https://git1-us-west.apache.org/repos/asf?p=guacamole-server.git;a=tag;h=0875ca8f4e86b942b466cfebf84cc33c47095130)
 
 
 Upload final release artifacts {#final-upload}
@@ -88,8 +88,7 @@ the images deployed for past release candidates were first cleaned with
 in the absence of an RC.
 
 For example, to build the `guacamole/guacamole` Docker image for the current
-release candidate, from within the top-level `incubator-guacamole-client`
-directory:
+release candidate, from within the top-level `guacamole-client` directory:
 
     $ git clean -xfd .
     $ sudo docker build -t guacamole/guacamole:0.9.11 .

--- a/release-procedure-part4.md
+++ b/release-procedure-part4.md
@@ -27,7 +27,7 @@ updated:
    to use the release directory (rather than the RC directory) and to *not*
    use `dist.apache.org`.
 
-Example: [the pull request for incubator-guacamole-website announcing 0.9.11-incubating](https://github.com/apache/incubator-guacamole-website/pull/31)
+Example: [the pull request for guacamole-website announcing 0.9.11-incubating](https://github.com/apache/guacamole-website/pull/31)
 
 Update JIRA version information {#update-jira}
 ----------------------------------------------


### PR DESCRIPTION
**SOME DOWNLOADS ARE CURRENTLY BROKEN** as the dist area has been renamed from `incubator/guacamole/` to `guacamole/`. This change corrects the affected releases, and also updates the links to the various git repositories to reflect the recent rename.