### PR TITLE
Add "Security Reports" page listing the vulnerabilities fixed in particular Guacamole releases.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,10 @@ collections:
     companies:
         output: false
 
+    # Public security vulnerabilities
+    security:
+        output: false
+
 # Site-wide defaults
 defaults:
 

--- a/_links/security.md
+++ b/_links/security.md
@@ -1,5 +1,5 @@
 ---
-menu-title:  Security
+menu-title:  Security Reports
 menu-weight: 4
-location:    http://www.apache.org/security/
+location:    /security/
 ---

--- a/_security/CVE-2012-4415.md
+++ b/_security/CVE-2012-4415.md
@@ -1,0 +1,14 @@
+---
+title: Buffer overflow in guac_client_plugin_open()
+cve:   CVE-2012-4415
+fixed: 0.6.3
+---
+
+A stack-based buffer overflow vulnerability was discovered in the
+`guac_client_plugin_open()` function in libguac in Guacamole before 0.6.3
+which could allow remote attackers to cause a denial of service (crash) or
+execute arbitrary code via a long protocol name.
+
+Acknowledgements: We would like to thank Timo Juhani Lindfors for reporting
+this issue.
+

--- a/_security/CVE-2016-1566.md
+++ b/_security/CVE-2016-1566.md
@@ -1,0 +1,14 @@
+---
+title: Stored cross-site scripting (XSS) in file browser
+cve:   CVE-2016-1566
+fixed: 0.9.9
+---
+
+A cross-site scripting (XSS) vulnerability was discovered through which files
+with specially-crafted filenames could lead to JavaScript execution if file
+transfer is enabled to a location which is shared by multiple users, and the
+filename is displayed within the file browser located within the Guacamole
+menu.
+
+Acknowledgements: We would like to thank Niv Levy for reporting this issue.
+

--- a/_security/CVE-2017-3158.md
+++ b/_security/CVE-2017-3158.md
@@ -1,0 +1,13 @@
+---
+title: Buffer overflow in SSH/telnet terminal emulator
+cve:   CVE-2017-3158
+fixed: 0.9.11-incubating
+---
+
+A race condition in Guacamole's terminal emulator could allow writes of blocks
+of printed data to overlap. Such overlapping writes could cause packet data to
+be misread as the packet length, resulting in the remaining data being written
+beyond the end of a statically-allocated buffer.
+
+Acknowledgements: We would like to thank Hariprasad Ng for reporting this
+issue.

--- a/security.md
+++ b/security.md
@@ -24,8 +24,14 @@ discussing the issue in a public forum.
 {% assign releases = site.security | group_by: 'fixed' %}
 {% for release in releases reversed %}
 
+{% assign asfrelease = site.releases | where: 'title', release.name %}
+{% if asfrelease != empty %}
 Fixed in Apache Guacamole {{ release.name }}
 --------------------------------------------
+{% else %}
+Fixed in Guacamole {{ release.name }} (pre-Apache release)
+----------------------------------------------------------
+{% endif %}
 
 <ul>
     {% assign reports = release.items | sort: 'title' %}

--- a/security.md
+++ b/security.md
@@ -22,7 +22,7 @@ the <private@guacamole.apache.org> mailing list, before disclosing or
 discussing the issue in a public forum.
 
 {% assign releases = site.security | group_by: 'fixed' %}
-{% for release in releases %}
+{% for release in releases reversed %}
 
 Fixed in Apache Guacamole {{ release.name }}
 --------------------------------------------

--- a/security.md
+++ b/security.md
@@ -1,0 +1,43 @@
+---
+layout: page 
+title: Security Reports
+permalink: /security/
+---
+
+This page lists all security vulnerabilities fixed in released versions of
+Apache Guacamole. Each vulnerability is listed with a description of the
+problem, its associated [CVE
+number](https://cve.mitre.org/about/faqs.html#what_is_cve_id), and the
+Guacamole release in which the vulnerability was fixed.
+
+Reporting new vulnerabilities
+-----------------------------
+
+If you believe you have discovered a security problem in Apache Guacamole,
+please follow [responsible
+disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) practices and
+report discovered security issues privately, either to the private security
+mailing list of the [ASF Security Team](https://www.apache.org/security/) or
+the <private@guacamole.apache.org> mailing list, before disclosing or
+discussing the issue in a public forum.
+
+{% assign releases = site.security | group_by: 'fixed' %}
+{% for release in releases %}
+
+Fixed in Apache Guacamole {{ release.name }}
+--------------------------------------------
+
+<ul>
+    {% assign reports = release.items | sort: 'title' %}
+    {% for report in reports %}
+    <li>
+        <h3 id="{{ report.cve }}">
+            {{ report.title }}
+            (<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ report.cve | url_encode }}">{{ report.cve }}</a>)
+        </h3>
+        {{ report.content }}
+    </li>
+    {% endfor %}
+</ul>
+{% endfor %}
+


### PR DESCRIPTION
This change adds a new "Security Reports" page which provides information on how to properly report discovered vulnerabilities, and lists all fixed and public vulnerabilities together with the version of Guacamole which introduced the fix.

For the sake of completeness, vulnerabilities fixed prior to the move to Apache are included here, but are given a different header.