### PR TITLE
GUACAMOLE-639: Add installation of libtool-bin for Debian/Ubuntu

### DIFF
--- a/doc/0.9.14/gug/installing-guacamole.html
+++ b/doc/0.9.14/gug/installing-guacamole.html
@@ -45,7 +45,9 @@
                                 <p>libpng is used by libguac to write PNG images, the core image
                                     type used by the Guacamole protocol. Guacamole cannot function
                                     without libpng.</p>
-                                <div class="informaltable"><table class="informaltable" border="0"><colgroup><col class="c1" /><col class="c2" /></colgroup><tbody><tr><th>Debian / Ubuntu package</th><td><span class="package">libpng12-dev</span></td></tr><tr><th>Fedora / CentOS / RHEL package</th><td><span class="package">libpng-devel</span></td></tr></tbody></table></div>
+                        <div class="informaltable"><table class="informaltable" border="0"><colgroup><col class="c1" /><col class="c2" /></colgroup><tbody><tr><th>Debian / Ubuntu package</th><td><span class="package">libpng12-dev</span></td></tr><tr><th>Fedora / CentOS / RHEL package</th><td><span class="package">libpng-devel</span></td></tr></tbody></table></div>
+                            </td></tr><tr><td><a class="link" href="https://www.gnu.org/software/libtool/manual/libtool.html" target="_top">libtool</a></td><td><p>libtool is used during the build process. libtool creates compiled libraries needed for Guacamole.</p>
+                                <div class="informaltable"><table class="informaltable" border="0"><colgroup><col class="c1" /><col class="c2" /></colgroup><tbody><tr><th>Debian / Ubuntu package</th><td><span class="package">libtool-bin</span></td></tr><tr><th>Fedora / CentOS / RHEL package</th><td><span class="package">libtool-devel</span></td></tr></tbody></table></div>
                             </td></tr><tr><td><a class="link" href="http://www.ossp.org/pkg/lib/uuid/" target="_top">OSSP
                                     UUID</a></td><td>
                                 <p>OSSP UUID is used by libguac to assign unique IDs to each


### PR DESCRIPTION
Fixes GUACAMOLE-639: Add installation of libtool-bin for Debian/Ubuntu

When building Apache Guacamole from source, libtool-bin is required on
Debian/Ubuntu systems. 

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>