### PR TITLE
GUACAMOLE-692: Update artifact checksums to comply with latest ASF release policy.

### DIFF
--- a/_includes/download-list.html
+++ b/_includes/download-list.html
@@ -14,9 +14,9 @@
                            'menu',
                            '{{ basename }}'
                        )">{{ basename }}</a></td>
-                <td>[ <a href="{{ dist | append: file }}.md5">MD5</a> ]</td>
-                <td>[ <a href="{{ dist | append: file }}.sha">SHA</a> ]</td>
-                <td>[ <a href="{{ dist | append: file }}.asc">PGP</a> ]</td>
+                {% for checksum in include.checksum-suffixes %}
+                    <td>[ <a href="{{ dist | append: file | append: checksum[1] }}">{{ checksum[0] }}</a> ]</td>
+                {% endfor %}
             </tr>
         {% endfor %}
     </table>

--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -32,6 +32,7 @@ below.</p>
     {% include download-list.html
         artifact-root=page.artifact-root
         checksum-root=page.checksum-root
+        checksum-suffixes=page.checksum-suffixes
         path=page.download-path
         files=page.source-dist %}
 </div>
@@ -46,6 +47,7 @@ still be built and installed from source.</strong></p>
     {% include download-list.html
         artifact-root=page.artifact-root
         checksum-root=page.checksum-root
+        checksum-suffixes=page.checksum-suffixes
         path=page.download-path
         files=page.binary-dist %}
 </div>

--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -10,6 +10,10 @@ summary: >
 artifact-root: "http://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.10-incubating/"
+checksum-suffixes:
+    "MD5" : ".md5"
+    "SHA" : ".sha"
+    "PGP" : ".asc"
 
 source-dist:
     - "source/guacamole-client-0.9.10-incubating.tar.gz"

--- a/_releases/0.9.11-incubating.md
+++ b/_releases/0.9.11-incubating.md
@@ -10,6 +10,10 @@ summary: >
 artifact-root: "http://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.11-incubating/"
+checksum-suffixes:
+    "MD5" : ".md5"
+    "SHA" : ".sha"
+    "PGP" : ".asc"
 
 source-dist:
     - "source/guacamole-client-0.9.11-incubating.tar.gz"

--- a/_releases/0.9.12-incubating.md
+++ b/_releases/0.9.12-incubating.md
@@ -11,6 +11,10 @@ summary: >
 artifact-root: "http://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.12-incubating/"
+checksum-suffixes:
+    "MD5" : ".md5"
+    "SHA" : ".sha"
+    "PGP" : ".asc"
 
 source-dist:
     - "source/guacamole-client-0.9.12-incubating.tar.gz"

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -10,6 +10,10 @@ summary: >
 artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
 checksum-root: "https://www.apache.org/dist/"
 download-path: "guacamole/0.9.13-incubating/"
+checksum-suffixes:
+    "MD5" : ".md5"
+    "SHA" : ".sha"
+    "PGP" : ".asc"
 
 source-dist:
     - "source/guacamole-client-0.9.13-incubating.tar.gz"

--- a/_releases/0.9.14.md
+++ b/_releases/0.9.14.md
@@ -11,6 +11,10 @@ summary: >
 artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
 checksum-root: "https://www.apache.org/dist/"
 download-path: "guacamole/0.9.14/"
+checksum-suffixes:
+    "MD5" : ".md5"
+    "SHA" : ".sha"
+    "PGP" : ".asc"
 
 source-dist:
     - "source/guacamole-client-0.9.14.tar.gz"

--- a/_releases/1.0.0.md
+++ b/_releases/1.0.0.md
@@ -11,9 +11,8 @@ artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
 checksum-root: "https://www.apache.org/dist/"
 download-path: "guacamole/1.0.0/"
 checksum-suffixes:
-    "MD5" : ".md5"
-    "SHA" : ".sha"
-    "PGP" : ".asc"
+    "PGP"     : ".asc"
+    "SHA-256" : ".sha256"
 
 source-dist:
     - "source/guacamole-client-1.0.0.tar.gz"

--- a/_releases/1.0.0.md
+++ b/_releases/1.0.0.md
@@ -10,6 +10,10 @@ summary: >
 artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
 checksum-root: "https://www.apache.org/dist/"
 download-path: "guacamole/1.0.0/"
+checksum-suffixes:
+    "MD5" : ".md5"
+    "SHA" : ".sha"
+    "PGP" : ".asc"
 
 source-dist:
     - "source/guacamole-client-1.0.0.tar.gz"


### PR DESCRIPTION
This change updates the release layout such that the specific checksums provided and the extensions used by those checksums can be specified on a per-release basis.

The ASF release policy changed last year to require (1) no MD5 and (2) a `.sha256` extension for SHA-256 (not the old `.sha`). These changes allow us to comply, and update the 1.0.0 release notes to do so.

Note that past releases are migrated to the new layout but not updated with respect to the new checksums. That's OK - we'll be archiving the older releases following 1.0.0.