### PR TITLE
Archive releases older than 1.0.0.

### DIFF
--- a/_layouts/legacy-release.html
+++ b/_layouts/legacy-release.html
@@ -3,11 +3,14 @@ layout: default
 permalink: /release/release-notes-:title
 ---
 
+{% assign latest = site.releases | where: 'released', 'true' | sort: 'date'  | last %}
 <div class="legacy-release-note">
     <p><strong>The release below is from prior to Guacamole's acceptance into
         the Apache Incubator.</strong> It is not an Apache Software Foundation
         release, and is licensed under the <a
-    href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
+     href="https://opensource.org/licenses/MIT">MIT license</a>. The latest
+     release of Apache Guacamole is <a href="{{ latest.url }}">{{
+         latest.title }}</a>.</p>
 </div>
 
 <div id="links">

--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -11,6 +11,16 @@ permalink: /release/release-notes-:title
     </div>
 {% endunless %}
 
+{% if page.archived %}
+    {% assign latest = site.releases | where: 'released', 'true' | sort: 'date'  | last %}
+    <div class="archive-disclaimer">
+        <p>Apache Guacamole {{ page.title }} is an archived release, and was
+        originally released on {{ page.date | date: "%Y-%m-%d" }}. <strong>The
+        latest release of Apache Guacamole is <a href="{{ latest.url }}">{{
+            latest.title }}</a>.</strong></p>
+    </div>
+{% endif %}
+
 <h1>Apache Guacamole {{ page.title }}</h1>
 
 <div id="links">

--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -1,6 +1,7 @@
 ---
 
 released: true
+archived: true
 title: 0.9.10-incubating
 date: 2016-12-29 19:52:00 -0800
 summary: >

--- a/_releases/0.9.11-incubating.md
+++ b/_releases/0.9.11-incubating.md
@@ -1,6 +1,7 @@
 ---
 
 released: true
+archived: false 
 title: 0.9.11-incubating
 date: 2017-02-02 09:24:00 -0800
 summary: >

--- a/_releases/0.9.11-incubating.md
+++ b/_releases/0.9.11-incubating.md
@@ -1,7 +1,7 @@
 ---
 
 released: true
-archived: false 
+archived: true
 title: 0.9.11-incubating
 date: 2017-02-02 09:24:00 -0800
 summary: >

--- a/_releases/0.9.12-incubating.md
+++ b/_releases/0.9.12-incubating.md
@@ -1,6 +1,7 @@
 ---
 
 released: true
+archived: true
 title: 0.9.12-incubating
 date: 2017-04-01 10:40:00 -0700
 summary: >

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -7,8 +7,8 @@ summary: >
     CAS single sign-on, fixes for VNC/RDP/SSH/telnet, in-browser playback of
     screen recordings, automatic connection failover, 256-color console codes.
 
-artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://www.apache.org/dist/"
+artifact-root: "http://archive.apache.org/dist/"
+checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/0.9.13-incubating/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -1,6 +1,7 @@
 ---
 
 released: true
+archived: true
 title: 0.9.13-incubating
 date: 2017-07-30 22:06:00 -0700
 summary: >

--- a/_releases/0.9.14.md
+++ b/_releases/0.9.14.md
@@ -8,8 +8,8 @@ summary: >
     login/logout history, fixes and improvements for RDP, clipboard, file
     transfer, and terminal emulation.
 
-artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://www.apache.org/dist/"
+artifact-root: "http://archive.apache.org/dist/"
+checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/0.9.14/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/0.9.14.md
+++ b/_releases/0.9.14.md
@@ -1,6 +1,7 @@
 ---
 
 released: true
+archived: true
 title: 0.9.14
 date: 2018-01-18 09:47:00 -0800
 summary: >

--- a/styles/main.css
+++ b/styles/main.css
@@ -555,7 +555,8 @@ table.releases td {
 }
 
 #content > .legacy-release-note,
-#content > .draft-disclaimer {
+#content > .draft-disclaimer,
+#content > .archive-disclaimer {
     background: #FFFFFA;
     border: 1px solid rgba(0, 0, 0, 0.25);
     width: 8in;


### PR DESCRIPTION
These changes archive the releases which are older than 1.0.0 (link to them only via archive.apache.org).

The release layout has also been modified to add a message at the top of the release notes pointing users at the latest release if they are currently looking at the release notes of an archived release.