### PR TITLE
Update ASF git URL to gitbox.apache.org.

### DIFF
--- a/pub/tests/guac/gitguac.js
+++ b/pub/tests/guac/gitguac.js
@@ -48,7 +48,7 @@ GIT_GUAC.COMMIT = (function getRequestedCommit() {
 GIT_GUAC.loadModule = function loadModule(filename) {
 
     // Construct URL pointing to guacamole-common-js module within ASF git
-    var url = 'https://git1-us-west.apache.org/repos/asf?'
+    var url = 'https://gitbox.apache.org/repos/asf?'
         + 'p=guacamole-client.git;'
         + 'a=blob_plain;'
         + 'f=guacamole-common-js/src/main/webapp/modules/' + encodeURIComponent(filename) + ';'


### PR DESCRIPTION
The old `git1-us-west.apache.org` service no longer exists. This breaks the keyboard event tester, which tries to pull the relevant guacamole-common-js modules from git. The URL should instead point to `gitbox.apache.org`.