### PR TITLE
Mark the 1.0.0 release as archived.

### DIFF
--- a/_releases/1.0.0.md
+++ b/_releases/1.0.0.md
@@ -1,14 +1,15 @@
 ---
 
 released: true
+archived: true
 title: 1.0.0
 date: 2019-01-08 19:42:00 -0800
 summary: >
     User groups, improved clipboard integration, TOTP (Google Authenticator),
     RADIUS, dead keys.
 
-artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://www.apache.org/dist/"
+artifact-root: "http://archive.apache.org/dist/"
+checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/1.0.0/"
 checksum-suffixes:
     "PGP"     : ".asc"


### PR DESCRIPTION
This change marks the 1.0.0 release as archived, linking to the release artifacts only via `archive.apache.org`. Setting the `archived` flag additionally produces a notice at the top of the release notes linking to the latest release (1.1.0).