### PR TITLE
Point to KEYS file and documentation on verifying release integrity.

### DIFF
--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -37,6 +37,13 @@ HTML5 web application which serves the Guacamole client to users, and
 communicates with. The source code for each of these may be downloaded
 below.</p>
 
+<p>You <strong>must</strong> <a href="https://www.apache.org/info/verification.html">
+verify the integrity of any downloaded files</a> using the OpenPGP signatures
+we provide with each release. The signatures should be verified against the
+<a href="https://www.apache.org/dist/guacamole/KEYS">KEYS</a>
+file, which contains the OpenPGP keys of Apache Guacamole's Release Managers.
+Checksums of each released file are also provided.</p>
+
 <!-- Source archives -->
 <div class="release-downloads">
     {% include download-list.html


### PR DESCRIPTION
The 1.1.0 release announcement to `announce@apache.org` was rejected this time around due to the download pages not pointing to the `KEYS` file nor describing how release artifacts can be verified. We've been requested to resubmit the announcement once the relevant pages have been updated.

This change adds a paragraph to each non-legacy release which points to the `KEYS` file and relevant documentation. I've looked to the download pages of other Apache projects for wording guidance.

Legacy (pre-Apache) releases are not affected.