### PR TITLE
Correct link to guacamole-common for draft 1.2.0-RC1 release notes.

### DIFF
--- a/_releases/1.2.0.md
+++ b/_releases/1.2.0.md
@@ -33,7 +33,7 @@ binary-dist:
 
 documentation:
     "Manual"              : "/doc/1.2.0/gug"
-    "guacamole-common"    : "/doc/1.2.0/guacamole-common"
+    "guacamole-common"    : "/doc/1.1.0/guacamole-common"
     "guacamole-common-js" : "/doc/1.2.0/guacamole-common-js"
     "guacamole-ext"       : "/doc/1.2.0/guacamole-ext"
     "libguac"             : "/doc/1.2.0/libguac"


### PR DESCRIPTION
guacamole-common didn't change this time around, so the documentation link should point to last release.