### PR TITLE
Add draft release notes for first RC of 1.3.0.

### DIFF
--- a/_releases/1.3.0.md
+++ b/_releases/1.3.0.md
@@ -1,0 +1,249 @@
+---
+
+released: false
+title: 1.3.0
+date: 2020-12-28 16:37:18 -0800
+summary: >
+    Automatic prompting for remote desktop credentials, user group support for
+    CAS and OpenID, bug fixes.
+
+artifact-root: "https://dist.apache.org/repos/dist/dev/"
+checksum-root: "https://dist.apache.org/repos/dist/dev/"
+download-path: "guacamole/1.3.0-RC1/"
+checksum-suffixes:
+    "PGP"     : ".asc"
+    "SHA-256" : ".sha256"
+
+source-dist:
+    - "source/guacamole-client-1.3.0.tar.gz"
+    - "source/guacamole-server-1.3.0.tar.gz"
+
+binary-dist:
+    - "binary/guacamole-1.3.0.war"
+    - "binary/guacamole-auth-cas-1.3.0.tar.gz"
+    - "binary/guacamole-auth-duo-1.3.0.tar.gz"
+    - "binary/guacamole-auth-header-1.2.0.tar.gz"
+    - "binary/guacamole-auth-jdbc-1.3.0.tar.gz"
+    - "binary/guacamole-auth-ldap-1.3.0.tar.gz"
+    - "binary/guacamole-auth-openid-1.3.0.tar.gz"
+    - "binary/guacamole-auth-quickconnect-1.3.0.tar.gz"
+    - "binary/guacamole-auth-saml-1.3.0.tar.gz"
+    - "binary/guacamole-auth-totp-1.3.0.tar.gz"
+
+documentation:
+    "Manual"              : "/doc/1.3.0/gug"
+    "guacamole-common"    : "/doc/1.3.0/guacamole-common"
+    "guacamole-common-js" : "/doc/1.3.0/guacamole-common-js"
+    "guacamole-ext"       : "/doc/1.3.0/guacamole-ext"
+    "libguac"             : "/doc/1.3.0/libguac"
+
+---
+
+The 1.3.0 release features support for automatically prompting users for their
+remote desktop credentials, user group support for both CAS and OpenID, and
+several bug fixes. For a full list of all changes in this release, please see
+the [changelog](#changelog).
+
+**The 1.3.0 release is compatible with older 1.x components.** You should
+upgrade older components to 1.3.0 when possible, however things should continue
+to work correctly in the interim:
+
+* Extensions written for older 1.x releases can be used by 1.3.0.
+* Components written for the version of the Guacamole protocol used by older
+  1.x releases can be used with components of the 1.3.0 release.
+
+Regardless of inter-component compatibility, **there are changes in 1.3.0 which
+may affect downstream users of Guacamole's APIs and the Guacamole protocol**.
+Please see the [deprecation / compatibility
+notes](#deprecation--compatibility-notes) section for more information.
+
+
+Automatic prompting for remote desktop credentials
+--------------------------------------------------
+
+Historically, Guacamole has required that remote desktop credentials either be
+stored alongside connection configuration, passed through from web application
+authentication (typically Active Directory), or retrieved interactively by the
+remote desktop itself.
+
+In addition to these methods, Guacamole will now automatically prompt the user
+to enter any credentials not already provided by the administrator if those
+credentials are required.
+
+
+User group support for CAS and OpenID
+-------------------------------------
+
+If using a CAS or OpenID identity provider to automatically sign in your users,
+user groups can now also be retrieved from the identity provider. Similar to
+the support already present for SAML, this support allows the admininstrator to
+define how user groups are exposed by the identity provider and allow those
+user groups to affect the permissions granted to their members within
+Guacamole.
+
+
+Changelog
+=========
+
+### User interface / platform
+
+ * Parameter prompting within client interface ([GUACAMOLE-221](https://issues.apache.org/jira/browse/GUACAMOLE-221))
+ * {:.bug} Objects may appear duplicated if access is granted via multiple groups ([GUACAMOLE-1021](https://issues.apache.org/jira/browse/GUACAMOLE-1021))
+ * Support automatic conversion of usernames to lowercase/uppercase via parameter tokens ([GUACAMOLE-1081](https://issues.apache.org/jira/browse/GUACAMOLE-1081))
+ * {:.bug} Ctrl+Alt+End(Supr) keyboard shortcut only works once ([GUACAMOLE-1125](https://issues.apache.org/jira/browse/GUACAMOLE-1125))
+ * {:.bug} Connection group permissions do not correctly determine presence of save/delete buttons ([GUACAMOLE-1150](https://issues.apache.org/jira/browse/GUACAMOLE-1150))
+
+### Docker images
+
+ * Add support for TOTP to Guacamole Docker image ([GUACAMOLE-753](https://issues.apache.org/jira/browse/GUACAMOLE-753))
+ * Add support for HTTP header authentication to Guacamole Docker image ([GUACAMOLE-857](https://issues.apache.org/jira/browse/GUACAMOLE-857))
+ * Update base image of Guacamole Docker image ([GUACAMOLE-980](https://issues.apache.org/jira/browse/GUACAMOLE-980))
+ * Add environment variables for `ldap-user-attributes` property to Guacamole Docker image ([GUACAMOLE-987](https://issues.apache.org/jira/browse/GUACAMOLE-987))
+ * Add support for CAS to Guacamole Docker image ([GUACAMOLE-1082](https://issues.apache.org/jira/browse/GUACAMOLE-1082))
+ * Run web application as reduced-privilege user within Guacamole Docker image ([GUACAMOLE-1110](https://issues.apache.org/jira/browse/GUACAMOLE-1110))
+ * Add environment variables for `ldap-dereference-aliases`, `ldap-follow-referrals`, `ldap-max-referral-hops`, and `ldap-operation-timeout` properties to Guacamole Docker image ([GUACAMOLE-1147](https://issues.apache.org/jira/browse/GUACAMOLE-1147))
+
+### Authentication, integration, and storage
+
+ * Add support for retrieving user groups from CAS ([GUACAMOLE-793](https://issues.apache.org/jira/browse/GUACAMOLE-793))
+ * Add support for retrieving user groups from OpenID ([GUACAMOLE-1172](https://issues.apache.org/jira/browse/GUACAMOLE-1172))
+ * {:.bug} PostgreSQL database connection may unexpectedly fail due to time out  ([GUACAMOLE-919](https://issues.apache.org/jira/browse/GUACAMOLE-919))
+ * {:.bug} Login using LDAP fails internally if TOTP is used without automatic user creation ([GUACAMOLE-1149](https://issues.apache.org/jira/browse/GUACAMOLE-1149))
+ * {:.bug} CAS module causes app.js download errors ([GUACAMOLE-1120](https://issues.apache.org/jira/browse/GUACAMOLE-1120))
+ * Allow server timezone info to be submitted to MySQL / MariaDB ([GUACAMOLE-760](https://issues.apache.org/jira/browse/GUACAMOLE-760))
+ * {:.bug} MySQL SSL truststore path must be a valid URL ([GUACAMOLE-1135](https://issues.apache.org/jira/browse/GUACAMOLE-1135))
+ * {:.bug} MySQL SSL client certificate properties incorrectly return truststore property values ([GUACAMOLE-1136](https://issues.apache.org/jira/browse/GUACAMOLE-1136))
+ * {:.bug} Query may fail if all connections disconnect while listing active connections ([GUACAMOLE-942](https://issues.apache.org/jira/browse/GUACAMOLE-942))
+ * {:.bug} RFC2865 requires NAS IP address to be submitted for RADIUS ([GUACAMOLE-1001](https://issues.apache.org/jira/browse/GUACAMOLE-1001))
+ * Standardize on filtered history query for user and connection management ([GUACAMOLE-1123](https://issues.apache.org/jira/browse/GUACAMOLE-1123))
+ * {:.bug} TOTP authentication fails when `totp-period` is set ([GUACAMOLE-1146](https://issues.apache.org/jira/browse/GUACAMOLE-1146))
+ * {:.bug} Enabling `skip-if-unavailable` breaks expired password change ([GUACAMOLE-1152](https://issues.apache.org/jira/browse/GUACAMOLE-1152))
+
+### Protocol support / guacd
+
+ * {:.bug} RDP log message incorrectly refers to "VNC" ([GUACAMOLE-982](https://issues.apache.org/jira/browse/GUACAMOLE-982))
+ * {:.bug} SFTP upload directory ignored for RDP connections ([GUACAMOLE-1031](https://issues.apache.org/jira/browse/GUACAMOLE-1031))
+ * {:.bug} RDP `disable-copy` flag does not work ([GUACAMOLE-1158](https://issues.apache.org/jira/browse/GUACAMOLE-1158))
+ * {:.bug} Memory allocated for outbound SVC PDUs may not be freed ([GUACAMOLE-1181](https://issues.apache.org/jira/browse/GUACAMOLE-1181))
+ * {:.bug} Memory allocated for outbound RDP clipboard data is not properly freed ([GUACAMOLE-1182](https://issues.apache.org/jira/browse/GUACAMOLE-1182))
+ * {:.bug} Thread mutexes within Guacamole's various supported protocols are not always cleanly destroyed ([GUACAMOLE-1114](https://issues.apache.org/jira/browse/GUACAMOLE-1114))
+ * {:.bug} RDP support may fail to build if SSH support is unavailable ([GUACAMOLE-1122](https://issues.apache.org/jira/browse/GUACAMOLE-1122))
+
+### Internationalization
+
+ * Update/improve Chinese translation ([GUACAMOLE-903](https://issues.apache.org/jira/browse/GUACAMOLE-903))
+ * Update/improve Russian translation ([GUACAMOLE-1054](https://issues.apache.org/jira/browse/GUACAMOLE-1054))
+ * Add support for Catalan language ([GUACAMOLE-1078](https://issues.apache.org/jira/browse/GUACAMOLE-1078))
+
+### Documentation
+
+ * {:.bug} Documented Duo secret key length is incorrect ([GUACAMOLE-819](https://issues.apache.org/jira/browse/GUACAMOLE-819))
+ * {:.bug} Guacamole Docker image documentation incorrectly states Docker links are supported for LDAP ([GUACAMOLE-912](https://issues.apache.org/jira/browse/GUACAMOLE-912))
+ * {:.bug} `allowed-languages` property incorrectly documented as `available-languages` ([GUACAMOLE-1107](https://issues.apache.org/jira/browse/GUACAMOLE-1107))
+
+### General housekeeping and cleanup
+
+ * Remove unused `UNIX_TIME` macro ([GUACAMOLE-949](https://issues.apache.org/jira/browse/GUACAMOLE-949))
+ * {:.bug} RDP comment incorrectly refers to "VNC" ([GUACAMOLE-1103](https://issues.apache.org/jira/browse/GUACAMOLE-1103))
+ * Exclude `nbproject/` directory from git via `.gitignore` ([GUACAMOLE-1151](https://issues.apache.org/jira/browse/GUACAMOLE-1151))
+
+
+Deprecation / Compatibility notes
+=================================
+
+Each 1.x release of Apache Guacamole should be compatible with components of
+older 1.x releases. This compatibility is intended at the Guacamole protocol
+level and at the extension level, but not necessarily at the API level. This
+means:
+
+ * Extensions from older 1.x releases should still work in binary form, but may
+   need code changes before their source will build against a newer version of
+   guacamole-ext.
+ * Software which uses the Guacamole protocol of an older 1.x release should
+   still work.
+ * Software which uses libguac from an older 1.x release should still work by
+   continuing to use the libguac from that release, as newer versions of
+   libguac may not be API/ABI compatible. In the case of third-party protocol
+   support plugins for guacd, this means that the guacd from that release must
+   also be used. Compatibility with respect to libguac is represented by the
+   [soname](https://en.wikipedia.org/wiki/Soname).
+ * You should update to newer versions where applicable and when possible.
+
+As of 1.3.0, the following changes have been made which affect compatibility
+with past releases:
+
+
+Java API (guacamole-common) changes
+-----------------------------------
+
+### Implementations of `GuacamoleSocket` should now implement `getProtocol()`
+
+The `required` and `argv` instructions both refer to connection parameters by
+name. As it is the underlying protocol of a connection that determines the
+semantics of connection parameters, client implementations will commonly need
+to expose this information in some way. The mainline web application provided
+by Apache Guacamole is one such implementation.
+
+A new `getProtocol()` function has been added to `GuacamoleSocket` to
+facilitate this, and implementations of `GuacamoleSocket` should aim to provide
+implementations of this function with that in mind.
+
+This will happen automatically for `ConfiguredGuacamoleSocket`.
+
+ * [GUACAMOLE-221](https://issues.apache.org/jira/browse/GUACAMOLE-221) - Parameter prompting within client interface
+
+
+Extension API (guacamole-ext) changes
+-------------------------------------
+
+### Deprecation of `getHistory()` for `User` and `Connection` interfaces
+
+The `User` and `Connection` interfaces have both continued to define a basic
+`getHistory()` function for retrieving a raw list of history records. Unlike
+the `getUserHistory()` and `getConnectionHistory()` functions exposed by the
+`UserContext`, the `getHistory()` functions do not support filtering or
+searching.
+
+The old `getHistory()` functions have now been deprecated in favor of newer
+functions that _do_ support filtering. Implementations that provide
+`getHistory()` will continue to work, but should migrate to the new functions
+when possible.
+
+ * [GUACAMOLE-1123](https://issues.apache.org/jira/browse/GUACAMOLE-1123) - Standardize on filtered history query for user and connection management
+
+
+Guacamole protocol changes
+--------------------------
+
+### The new `required` instruction
+
+To allow the server to request that the client provide credentials (or any
+other parameters), a new `required` instruction has been added to the Guacamole
+protocol. This instruction informs the client that one or more connection
+parameters need to be specified for the connection to continue. If the client
+indicated support for the `required` instruction during the initial connection
+handshake, the client is then expected to supply values for each of these
+parameters using `argv` streams.
+
+ * [GUACAMOLE-221](https://issues.apache.org/jira/browse/GUACAMOLE-221) - Parameter prompting within client interface
+
+
+libguac API changes
+-------------------
+
+### `protocol_version` added to `guac_user_info` structure
+
+A new `protocol_version` member has been added to `guac_user_info` to allow
+implementations to make decisions based on the Guacamole protocol version in
+use, affecting the size of this structure.
+
+Additionally, because `guac_user_info` forms a part of `guac_user`, this change
+also affects the memory offsets of members of the `guac_user` structure which
+follow the `info` member, such as `data` and various instruction handlers.
+
+Downstream usages of libguac which make use of `guac_user` or `guac_user_info`
+will need to be rebuilt to ensure that the structure sizes and memory offsets
+used are correct.
+
+ * [GUACAMOLE-221](https://issues.apache.org/jira/browse/GUACAMOLE-221) - Parameter prompting within client interface
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -554,6 +554,13 @@ table.releases td {
     padding-right: 1em;
 }
 
+#release-notes li.bug:before {
+    content: 'Bug: ';
+    text-transform: uppercase;
+    color: red;
+    font-style: italic;
+}
+
 #content > .legacy-release-note,
 #content > .draft-disclaimer,
 #content > .archive-disclaimer {


### PR DESCRIPTION
I've deviated from the past release notes structure a bit here, adding paragraph summaries for only a couple highlighted features. All other changes/fixes are instead listed in an exhaustive changelog that is grouped by category.

Assuming this style is OK, this should greatly reduce the work required for release notes going forward, as the changelog is the sort of thing that can be almost entirely automated with data from JIRA.