### PR TITLE
Document vulnerability CVE-2020-11997, fixed in 1.3.0.

### DIFF
--- a/_includes/cve-list.html
+++ b/_includes/cve-list.html
@@ -1,0 +1,15 @@
+{% if include.reports != empty %}
+{{ include.title }}
+-------------------
+<ul>
+    {% for report in include.reports %}
+        <li>
+            <h3 id="{{ report.cve }}">
+                {{ report.title }}
+                (<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ report.cve | url_encode }}">{{ report.cve }}</a>)
+            </h3>
+            {{ report.content }}
+        </li>
+    {% endfor %}
+</ul>
+{% endif %}

--- a/_security/CVE-2020-11997.md
+++ b/_security/CVE-2020-11997.md
@@ -1,0 +1,16 @@
+---
+title: Inconsistent restriction of connection history visibility
+cve:   CVE-2020-11997
+fixed: 1.3.0
+---
+
+Apache Guacamole 1.2.0 and older do not consistently restrict access to
+connection history based on user visibility. If multiple users share access to
+the same connection, those users may be able to see which other users have
+accessed that connection, as well as the IP addresses from which that
+connection was accessed, even if those users do not otherwise have permission
+to see other users.
+
+Acknowledgements: We would like to thank William Le Berre (Synetis) for
+reporting this issue.
+

--- a/security.md
+++ b/security.md
@@ -21,29 +21,25 @@ mailing list of the [ASF Security Team](https://www.apache.org/security/) or
 the <security@guacamole.apache.org> mailing list, before disclosing or
 discussing the issue in a public forum.
 
-{% assign releases = site.security | group_by: 'fixed' %}
+{% assign releases = site.releases  | where: 'released', 'true' | sort: 'date' %}
 {% for release in releases reversed %}
 
-{% assign asfrelease = site.releases | where: 'title', release.name %}
-{% if asfrelease != empty %}
-Fixed in Apache Guacamole {{ release.name }}
---------------------------------------------
-{% else %}
-Fixed in Guacamole {{ release.name }} (pre-Apache release)
-----------------------------------------------------------
-{% endif %}
+    {% assign reports = site.security | where: 'fixed', release.title | sort: 'title' %}
+    {% capture title %} Fixed in Apache Guacamole {{ release.title }} {% endcapture %}
+    {% include cve-list.html title=title reports=reports %}
 
-<ul>
-    {% assign reports = release.items | sort: 'title' %}
-    {% for report in reports %}
-    <li>
-        <h3 id="{{ report.cve }}">
-            {{ report.title }}
-            (<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ report.cve | url_encode }}">{{ report.cve }}</a>)
-        </h3>
-        {{ report.content }}
-    </li>
-    {% endfor %}
-</ul>
 {% endfor %}
+
+{% assign releases = site.legacy-releases | sort: 'date' %}
+{% for release in releases reversed %}
+
+    {% assign reports = site.security | where: 'fixed', release.title | sort: 'title' %}
+    {% capture title %} Fixed in Guacamole {{ release.title }} (pre-Apache release) {% endcapture %}
+    {% include cve-list.html title=title reports=reports %}
+
+{% endfor %}
+
+{% assign reports = site.security | where: 'fixed', '0.6.3' | sort: 'title' %}
+{% capture title %} Fixed in Guacamole 0.6.3 (pre-Apache release) {% endcapture %}
+{% include cve-list.html title=title reports=reports %}
 


### PR DESCRIPTION
Part of this involved reworking the way the `security.md` page renders reports, as release version numbers were not sorting correctly as of this addition. I've modified `security.md` such that it iterates through releases by date, rather than iterating through reports by fix version.