### PR TITLE
Use HTTPS for all download links.

### DIFF
--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -8,7 +8,7 @@ summary: >
     Screen sharing, recording, improved file transfer, audio input, Docker
     support for LDAP.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.10-incubating/"
 checksum-suffixes:

--- a/_releases/0.9.11-incubating.md
+++ b/_releases/0.9.11-incubating.md
@@ -8,7 +8,7 @@ summary: >
     Two-factor authentication, password policies, improvements to Docker and
     LDAP.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.11-incubating/"
 checksum-suffixes:

--- a/_releases/0.9.12-incubating.md
+++ b/_releases/0.9.12-incubating.md
@@ -9,7 +9,7 @@ summary: >
     improvements, and fixes for printing, file transfer, and terminal
     emulation.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.12-incubating/"
 checksum-suffixes:

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -8,7 +8,7 @@ summary: >
     CAS single sign-on, fixes for VNC/RDP/SSH/telnet, in-browser playback of
     screen recordings, automatic connection failover, 256-color console codes.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/0.9.13-incubating/"
 checksum-suffixes:

--- a/_releases/0.9.14.md
+++ b/_releases/0.9.14.md
@@ -9,7 +9,7 @@ summary: >
     login/logout history, fixes and improvements for RDP, clipboard, file
     transfer, and terminal emulation.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/0.9.14/"
 checksum-suffixes:

--- a/_releases/1.0.0.md
+++ b/_releases/1.0.0.md
@@ -8,7 +8,7 @@ summary: >
     User groups, improved clipboard integration, TOTP (Google Authenticator),
     RADIUS, dead keys.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/1.0.0/"
 checksum-suffixes:

--- a/_releases/1.1.0.md
+++ b/_releases/1.1.0.md
@@ -9,7 +9,7 @@ summary: >
     and Apache Directory API, fixes and improvements to Docker images, terminal
     behavior, and user groups.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/1.1.0/"
 checksum-suffixes:

--- a/_releases/1.2.0.md
+++ b/_releases/1.2.0.md
@@ -9,7 +9,7 @@ summary: >
     connections, numerous fixes for RDP, improvements to TOTP, database
     support, and behavior on iOS devices.
 
-artifact-root: "http://archive.apache.org/dist/"
+artifact-root: "https://archive.apache.org/dist/"
 checksum-root: "https://archive.apache.org/dist/"
 download-path: "guacamole/1.2.0/"
 checksum-suffixes:

--- a/_releases/1.3.0.md
+++ b/_releases/1.3.0.md
@@ -7,7 +7,7 @@ summary: >
     Automatic prompting for remote desktop credentials, user group support for
     CAS and OpenID, bug fixes.
 
-artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
+artifact-root: "https://apache.org/dyn/closer.cgi?action=download&filename="
 checksum-root: "https://www.apache.org/dist/"
 download-path: "guacamole/1.3.0/"
 checksum-suffixes:


### PR DESCRIPTION
Chrome is now automatically blocking downloads via unencrypted HTTP for pages that are otherwise served over HTTPS. This will cause trouble for any user that attempts to download Guacamole while visiting the site over HTTPS.

See: https://lists.apache.org/thread.html/r1ca1f9b0f36e70b6c2d218ce356fd64f641fbffbca40cd7b8595bb7e%40%3Cdev.guacamole.apache.org%3E