### PR TITLE
Update www.apache.org/dist/ links to downloads.apache.org.

### DIFF
--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -40,7 +40,7 @@ below.</p>
 <p>You <strong>must</strong> <a href="https://www.apache.org/info/verification.html">
 verify the integrity of any downloaded files</a> using the OpenPGP signatures
 we provide with each release. The signatures should be verified against the
-<a href="https://www.apache.org/dist/guacamole/KEYS">KEYS</a>
+<a href="https://downloads.apache.org/guacamole/KEYS">KEYS</a>
 file, which contains the OpenPGP keys of Apache Guacamole's Release Managers.
 Checksums of each released file are also provided.</p>
 

--- a/_releases/1.3.0.md
+++ b/_releases/1.3.0.md
@@ -8,7 +8,7 @@ summary: >
     CAS and OpenID, bug fixes.
 
 artifact-root: "https://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://www.apache.org/dist/"
+checksum-root: "https://downloads.apache.org/"
 download-path: "guacamole/1.3.0/"
 checksum-suffixes:
     "PGP"     : ".asc"


### PR DESCRIPTION
ASF Infra sent out an email early last year stating that the `www.apache.org/dist/` download location is deprecated in favor of `downloads.apache.org`. Attempts to visit links at the old location will still work, but will be redirected to the new location, and projects are requested to update any applicable links when they can.

This change performs that update for the only references we currently have to the old location:

* The link to the project `KEYS` file.
* The checksum root for the 1.3.0 release notes.
