### PR TITLE
 Migrate to closer.lua download URL format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 content
 _site
 .sass-cache
+.jekyll-cache
 .jekyll-metadata

--- a/_includes/download-list.html
+++ b/_includes/download-list.html
@@ -1,11 +1,11 @@
 {% if include.files != empty %}
     <table>
+        {% assign filename_token = "{}" %}
         {% for file in include.files %}
             <tr>
-                {% assign mirror = include.artifact-root | append: include.path %}
-                {% assign dist = include.checksum-root | append: include.path %}
+                {% assign filename = include.path | append: file %}
                 {% assign basename = file | split: "/" | last %}
-                <td><a href="{{ mirror | append: file }}"
+                <td><a href="{{ include.artifact-url | replace: filename_token, filename }}"
                        onclick="trackDownload(
                            'click',
                            '{{ basename }}'
@@ -15,7 +15,8 @@
                            '{{ basename }}'
                        )">{{ basename }}</a></td>
                 {% for checksum in include.checksum-suffixes %}
-                    <td>[ <a href="{{ dist | append: file | append: checksum[1] }}">{{ checksum[0] }}</a> ]</td>
+                    {% assign checksum_filename = include.path | append:file | append: checksum[1] %}
+                    <td>[ <a href="{{ include.checksum-url | replace: filename_token, checksum_filename }}">{{ checksum[0] }}</a> ]</td>
                 {% endfor %}
             </tr>
         {% endfor %}

--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -47,8 +47,8 @@ Checksums of each released file are also provided.</p>
 <!-- Source archives -->
 <div class="release-downloads">
     {% include download-list.html
-        artifact-root=page.artifact-root
-        checksum-root=page.checksum-root
+        artifact-url=page.artifact-url
+        checksum-url=page.checksum-url
         checksum-suffixes=page.checksum-suffixes
         path=page.download-path
         files=page.source-dist %}
@@ -62,8 +62,8 @@ still be built and installed from source.</strong></p>
 <!-- All binaries -->
 <div class="release-downloads">
     {% include download-list.html
-        artifact-root=page.artifact-root
-        checksum-root=page.checksum-root
+        artifact-url=page.artifact-url
+        checksum-url=page.checksum-url
         checksum-suffixes=page.checksum-suffixes
         path=page.download-path
         files=page.binary-dist %}

--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -8,8 +8,8 @@ summary: >
     Screen sharing, recording, improved file transfer, audio input, Docker
     support for LDAP.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "incubator/guacamole/0.9.10-incubating/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/0.9.11-incubating.md
+++ b/_releases/0.9.11-incubating.md
@@ -8,8 +8,8 @@ summary: >
     Two-factor authentication, password policies, improvements to Docker and
     LDAP.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "incubator/guacamole/0.9.11-incubating/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/0.9.12-incubating.md
+++ b/_releases/0.9.12-incubating.md
@@ -9,8 +9,8 @@ summary: >
     improvements, and fixes for printing, file transfer, and terminal
     emulation.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "incubator/guacamole/0.9.12-incubating/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -8,8 +8,8 @@ summary: >
     CAS single sign-on, fixes for VNC/RDP/SSH/telnet, in-browser playback of
     screen recordings, automatic connection failover, 256-color console codes.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "guacamole/0.9.13-incubating/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/0.9.14.md
+++ b/_releases/0.9.14.md
@@ -9,8 +9,8 @@ summary: >
     login/logout history, fixes and improvements for RDP, clipboard, file
     transfer, and terminal emulation.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "guacamole/0.9.14/"
 checksum-suffixes:
     "MD5" : ".md5"

--- a/_releases/1.0.0.md
+++ b/_releases/1.0.0.md
@@ -8,8 +8,8 @@ summary: >
     User groups, improved clipboard integration, TOTP (Google Authenticator),
     RADIUS, dead keys.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "guacamole/1.0.0/"
 checksum-suffixes:
     "PGP"     : ".asc"

--- a/_releases/1.1.0.md
+++ b/_releases/1.1.0.md
@@ -9,8 +9,8 @@ summary: >
     and Apache Directory API, fixes and improvements to Docker images, terminal
     behavior, and user groups.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "guacamole/1.1.0/"
 checksum-suffixes:
     "PGP"     : ".asc"

--- a/_releases/1.2.0.md
+++ b/_releases/1.2.0.md
@@ -9,8 +9,8 @@ summary: >
     connections, numerous fixes for RDP, improvements to TOTP, database
     support, and behavior on iOS devices.
 
-artifact-root: "https://archive.apache.org/dist/"
-checksum-root: "https://archive.apache.org/dist/"
+artifact-url: "https://archive.apache.org/dist/{}"
+checksum-url: "https://archive.apache.org/dist/{}"
 download-path: "guacamole/1.2.0/"
 checksum-suffixes:
     "PGP"     : ".asc"

--- a/_releases/1.3.0.md
+++ b/_releases/1.3.0.md
@@ -7,8 +7,8 @@ summary: >
     Automatic prompting for remote desktop credentials, user group support for
     CAS and OpenID, bug fixes.
 
-artifact-root: "https://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://downloads.apache.org/"
+artifact-url: "https://apache.org/dyn/closer.lua/{}?action=download"
+checksum-url: "https://downloads.apache.org/{}"
 download-path: "guacamole/1.3.0/"
 checksum-suffixes:
     "PGP"     : ".asc"

--- a/build.sh
+++ b/build.sh
@@ -76,7 +76,7 @@ assert_directory() {
 ##
 assert_program() {
     NAME="$1"
-    if ! which "$NAME" &> /dev/null; then
+    if ! which "$NAME" 2>&1 > /dev/null; then
         log "FATAL: \"$NAME\" is not installed."
         exit 1
     fi

--- a/release-procedure-part4.md
+++ b/release-procedure-part4.md
@@ -23,7 +23,7 @@ updated:
    in the [release archives](/releases/). The `date` field should also be
    updated to note the actual date and time of release.
 
-3. The `artifact-root`, `checksum-root`, and `download-path` must be updated
+3. The `artifact-url`, `checksum-url`, and `download-path` must be updated
    to use the release directory (rather than the RC directory) and to *not*
    use `dist.apache.org`.
 


### PR DESCRIPTION
To address [the unexpected download page breakage noted on the dev@ list](https://lists.apache.org/thread.html/re2e43209be94e0735593f49d85122e1d2a9812fdc3d1b688d0f2a63e%40%3Cdev.guacamole.apache.org%3E) (see [INFRA-21767](https://issues.apache.org/jira/browse/INFRA-21767?focusedCommentId=17327019&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17327019)), this change migrates the download URL format from:

    https://apache.org/dyn/closer.cgi?action=download&filename=PATH/TO/FILE

to:

    https://apache.org/dyn/closer.lua/PATH/TO/FILE?action=download

As the new format involves inserting the download path _within_ the URL rather than simply appending the path, these changes migrate to a substitution mechanism where "{}" is used as a placeholder for the filename (similar to the format used by the find utility and various logging backends).