### PR TITLE
Clarify that Guacamole uses Logback for its logging backend.

### DIFF
--- a/security.md
+++ b/security.md
@@ -21,6 +21,12 @@ mailing list of the [ASF Security Team](https://www.apache.org/security/) or
 the <security@guacamole.apache.org> mailing list, before disclosing or
 discussing the issue in a public forum.
 
+Is Apache Guacamole affected by CVE-2021-44228? {#not-affected-by-cve-2021-44228}
+-----------------------------------------------
+
+No, CVE-2021-44228 does not affect Apache Guacamole. Guacamole uses
+[Logback](http://logback.qos.ch/) as its logging backend, not Log4j.
+
 {% assign releases = site.releases  | where: 'released', 'true' | sort: 'date' %}
 {% for release in releases reversed %}
 


### PR DESCRIPTION
This change clarifies that Guacamole uses Logback as its logging backend and therefore is not affected by CVE-2021-44228.

It is not immediately obvious to users that Guacamole does not actually use Log4j. Lacking any explicit statement to the contrary, users assume that Log4j is used because it is so ubiquitous, and are naturally concerned when they do not see an update for mitigating CVE-2021-44228. They cannot be expected to know that no update is necessary.

This should hopefully serve as sufficient clarification.