### PR TITLE
Change GUACD_POST to GUACD_PORT

### DIFF
--- a/doc/1.4.0/gug/_sources/guacamole-docker.md.txt
+++ b/doc/1.4.0/gug/_sources/guacamole-docker.md.txt
@@ -146,7 +146,7 @@ network connection information yourself using additional environment variables:
 : The hostname of the guacd instance to use to establish remote desktop
   connections. *This is required if you are not using Docker to provide guacd.*
 
-`GUACD_POST`
+`GUACD_PORT`
 : The port that Guacamole should use when connecting to guacd. This environment
   variable is optional. If not provided, the standard guacd port of 4822 will
   be used.

--- a/doc/1.4.0/gug/guacamole-docker.html
+++ b/doc/1.4.0/gug/guacamole-docker.html
@@ -353,7 +353,7 @@ network connection information yourself using additional environment variables:<
 <dt><code class="docutils literal notranslate"><span class="pre">GUACD_HOSTNAME</span></code></dt><dd><p>The hostname of the guacd instance to use to establish remote desktop
 connections. <em>This is required if you are not using Docker to provide guacd.</em></p>
 </dd>
-<dt><code class="docutils literal notranslate"><span class="pre">GUACD_POST</span></code></dt><dd><p>The port that Guacamole should use when connecting to guacd. This environment
+<dt><code class="docutils literal notranslate"><span class="pre">GUACD_PORT</span></code></dt><dd><p>The port that Guacamole should use when connecting to guacd. This environment
 variable is optional. If not provided, the standard guacd port of 4822 will
 be used.</p>
 </dd>


### PR DESCRIPTION
I think `GUACD_POST` is a typo. Changed to `GUACD_PORT`.