### PR TITLE
Corrected typo in package name

### DIFF
--- a/doc/1.4.0/gug/_sources/installing-guacamole.md.txt
+++ b/doc/1.4.0/gug/_sources/installing-guacamole.md.txt
@@ -174,7 +174,7 @@ carefully before deciding not to install an optional dependency.
   :::{list-table}
   :stub-columns: 1
   * - Debian / Ubuntu package
-    - `libavcodec-dev`, `libavformat-dev`, `libavutil-dev`, `libswsccale-dev`
+    - `libavcodec-dev`, `libavformat-dev`, `libavutil-dev`, `libswscale-dev`
   * - Fedora / CentOS / RHEL package
     - `ffmpeg-devel`
   :::

--- a/doc/1.4.0/gug/installing-guacamole.html
+++ b/doc/1.4.0/gug/installing-guacamole.html
@@ -419,7 +419,7 @@ not wish to translate such recordings into video, then FFmpeg is not needed.</p>
 </colgroup>
 <tbody>
 <tr class="row-odd"><th class="stub"><p>Debian / Ubuntu package</p></th>
-<td><p><code class="docutils literal notranslate"><span class="pre">libavcodec-dev</span></code>, <code class="docutils literal notranslate"><span class="pre">libavformat-dev</span></code>, <code class="docutils literal notranslate"><span class="pre">libavutil-dev</span></code>, <code class="docutils literal notranslate"><span class="pre">libswsccale-dev</span></code></p></td>
+<td><p><code class="docutils literal notranslate"><span class="pre">libavcodec-dev</span></code>, <code class="docutils literal notranslate"><span class="pre">libavformat-dev</span></code>, <code class="docutils literal notranslate"><span class="pre">libavutil-dev</span></code>, <code class="docutils literal notranslate"><span class="pre">libswscale-dev</span></code></p></td>
 </tr>
 <tr class="row-even"><th class="stub"><p>Fedora / CentOS / RHEL package</p></th>
 <td><p><code class="docutils literal notranslate"><span class="pre">ffmpeg-devel</span></code></p></td>


### PR DESCRIPTION
Package name was incorrect in Guacamole documentation for Ubuntu / Debian. Contained an extra "c"