### PR TITLE
GUACAMOLE-1754: Add new Dockerfile for local testing, and run docker build for PR CI using it.

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,29 @@
+name: Pull request CI build
+
+# Run build for all pull requests
+on:
+  pull_request:
+
+# Limit to only one build for a given PR source branch at a time,
+# cancelling any in-progress builds
+concurrency:
+  group: guacamole-website-pr-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  docker_build:
+    name: Run docker build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build Docker container
+        shell: sh
+        run: |
+          docker build --pull --no-cache --force-rm .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Dockerfile for guacamole-website
+# 
+# See the README for more information on how to use this file.
+
+# Perform the build using ruby and jekyll 
+FROM ruby
+
+# Install jeykll
+RUN gem install jekyll bundler
+
+# Set the working directory for the remainder of the build process
+WORKDIR /website
+
+# Copy the website source into the working directory and build it
+COPY ./ ./
+RUN ./build.sh
+
+# The port at which the website should be hosted. Make sure to
+# expose this port when running this docker image.
+ENV PORT=8080
+
+# Host the website at the configured port
+CMD ["sh", "-c", "./build.sh ${PORT}"] 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ licensed project, the repository contains the following critical files:
 | `add-tracking.pl` | Utility script which edits specified HTML files in-place, adding the project's Google Analytics tracking code at the end of the `<body>` (requires Perl).
 | `build.sh`    | The website build script (usage documented below).
 | `doc/`        | Per-release documentation for Apache Guacamole. This directory contains one subdirectory per release, where each subdirectory contains the overall manual (`.../gug/`) API documentation for each part of the Guacamole core (`.../libguac/`, `.../guacamole-common/`, etc.). Files in this directory are not interpreted by Jekyll, as there are far too many files for this to be reasonable. They are instead copied into place by the `build.sh` script.
+| `Dockerfile`  | A docker file that can be used to build and serve the website.
 | `images/`     | Images which are referenced within the website HTML and CSS.
 | `pub/`        | Miscellaneous public files, such as test scripts. The test scripts in this directory have historically been shared to users to help with debugging.
 | `styles/`     | All CSS files referenced by the website HTML.
@@ -87,6 +88,16 @@ To test your changes to the website, you can either invoke `./build.sh` to build
 
 When done testing your local changes, press `Ctrl`&nbsp;+&nbsp;`C` to stop the
 web server and return to the shell.
+
+Build and serve using docker
+-----------------------
+
+Alternatively, as opposed to installing Jekyll locally, the website can be built and served locally using the provided `Dockerfile`. To build and serve the website locally, simply build a Docker container containing the current website and run the container, as below.
+
+1. Build a new docker image: `docker build . -tag some-website`.
+2. Run the docker image at a configured port: `docker run -e PORT=8080 -p 8080:8080 -it --rm some-website`
+
+The website will be served just as when `build.sh` is invoked directly. Press `Ctrl`&nbsp;+&nbsp;`C` to stop the docker container. 
 
 Publishing changes
 ------------------


### PR DESCRIPTION
Add PR verification job to guacamole-server. See discussion on the equivalent client PR for more: https://github.com/apache/guacamole-client/pull/811.

I added a `Dockerfile` for the CI build and some docs about how to build / serve the website locally using it.