### PR TITLE
Oracle Linux - Supported for required packages: Cairo, libjpeg-turbo,…

### DIFF
--- a/doc/1.5.5/gug/_sources/installing-guacamole.md.txt
+++ b/doc/1.5.5/gug/_sources/installing-guacamole.md.txt
@@ -54,7 +54,7 @@ are strictly required *in all cases* - Guacamole cannot be built without them.
   :stub-columns: 1
   * - Debian / Ubuntu package
     - `libcairo2-dev`
-  * - Fedora / CentOS / RHEL package
+  * - Fedora / CentOS / RHEL package / Oracle Linux
     - `cairo-devel`
   :::
 
@@ -68,7 +68,7 @@ are strictly required *in all cases* - Guacamole cannot be built without them.
     - `libjpeg62-turbo-dev`
   * - Ubuntu package
     - `libjpeg-turbo8-dev`
-  * - Fedora / CentOS / RHEL package
+  * - Fedora / CentOS / RHEL package / Oracle Linux
     - `libjpeg-turbo-devel`
   :::
 
@@ -92,7 +92,7 @@ are strictly required *in all cases* - Guacamole cannot be built without them.
   :stub-columns: 1
   * - Debian / Ubuntu package
     - `libpng-dev`
-  * - Fedora / CentOS / RHEL package
+  * - Fedora / CentOS / RHEL package / Oracle Linux
     - `libpng-devel`
   :::
 
@@ -113,7 +113,7 @@ are strictly required *in all cases* - Guacamole cannot be built without them.
   :stub-columns: 1
   * - Debian / Ubuntu package
     - `libtool-bin`
-  * - Fedora / CentOS / RHEL package
+  * - Fedora / CentOS / RHEL package / Oracle Linux
     - `libtool`
   :::
 


### PR DESCRIPTION
 ### **Test Summary on Oracle Linux Versions 7, 8, and 9 - Package Installation Verification**

I have conducted a series of tests on _**Oracle Linux versions 7, 8, and 9**_ to verify the successful installation of several critical development packages. The packages tested include:
**cairo-devel
libjpeg-turbo-devel
libpng-devel
libtool
libuuid-devel**

These tests were carried out using the standard installation commands provided for each package. The results confirm that all the listed packages are installable on the specified Oracle Linux versions without any issues.

To ensure that this pull request meets all necessary criteria and gets approved, could you please provide a list of the required submissions for verification? This may include any additional test results, logs, or specific documentation that needs to be reviewed.

