### PR TITLE
Note that "Guacamole" is a registered trademark.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@
 #
 
 # Site settings
-title: Apache Guacamole™
+title: Apache Guacamole®
 
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,9 +12,9 @@
 
         <!-- Trademarks -->
         <p class="trademarks">
-            Apache Guacamole, Guacamole, Apache, the Apache feather logo, and the
-            Apache Guacamole project logo are trademarks of The Apache Software
-            Foundation.
+            Apache Guacamole, Guacamole, Apache, the Apache feather logo, and
+            the Apache Guacamole project logo are trademarks or registered
+            trademarks of The Apache Software Foundation.
         </p>
 
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!-- Header -->
 <div id="header">
     <div class="readable-content">
-        <h1><a href="/">{{ site.title }}</a></h1>
+        <h1><a href="/">{{ site.title | replace: "®", "<sup>®</sup>" }}</a></h1>
         <ul id="navigation" class="menu">
             {% include nav-menu.html path="_links" %}
         </ul>


### PR DESCRIPTION
As the "Guacamole" trademark is now officially registered, we must:

* Update the notation on the website from `™` to `®`.
* Note that the trademark is a registered trademark in the footer.