### PR TITLE
Add extension links missing from draft 1.6.0 release notes.

### DIFF
--- a/_releases/1.6.0.md
+++ b/_releases/1.6.0.md
@@ -20,6 +20,7 @@ source-dist:
 
 binary-dist:
     - "binary/guacamole-1.6.0.war"
+    - "binary/guacamole-auth-ban-1.6.0.tar.gz"
     - "binary/guacamole-auth-duo-1.6.0.tar.gz"
     - "binary/guacamole-auth-header-1.6.0.tar.gz"
     - "binary/guacamole-auth-jdbc-1.6.0.tar.gz"
@@ -27,7 +28,9 @@ binary-dist:
     - "binary/guacamole-auth-ldap-1.6.0.tar.gz"
     - "binary/guacamole-auth-quickconnect-1.6.0.tar.gz"
     - "binary/guacamole-auth-sso-1.6.0.tar.gz"
+    - "binary/guacamole-auth-restrict-1.6.0.tar.gz"
     - "binary/guacamole-auth-totp-1.6.0.tar.gz"
+    - "binary/guacamole-display-statistics-1.6.0.tar.gz"
     - "binary/guacamole-history-recording-storage-1.6.0.tar.gz"
     - "binary/guacamole-vault-1.6.0.tar.gz"
 


### PR DESCRIPTION
Forgot a few extension links that are new to 1.6.0:

* guacamole-auth-ban
* guacamole-auth-restrict
* guacamole-display-statistics